### PR TITLE
load only x value of voxel size

### DIFF
--- a/src/membrain_pick/mesh_projections/mesh_conversion_wrappers.py
+++ b/src/membrain_pick/mesh_projections/mesh_conversion_wrappers.py
@@ -161,7 +161,7 @@ def mesh_for_tomo_mb_folder(
     if tomo is None:
         tomo = load_tomogram(tomo_file)
         input_pixel_size = (
-            tomo.voxel_size if input_pixel_size is None else input_pixel_size
+            tomo.voxel_size.x if input_pixel_size is None else input_pixel_size
         )
         tomo = tomo.data
         if tomo_token is None:
@@ -215,7 +215,7 @@ def mesh_for_single_mb_file(
     if tomo is None:
         tomo = load_tomogram(tomo_file)
         input_pixel_size = (
-            tomo.voxel_size if input_pixel_size is None else input_pixel_size
+            tomo.voxel_size.x if input_pixel_size is None else input_pixel_size
         )
         tomo = tomo.data
         if tomo_token is None:


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/CellArchLab/membrain-pick/issues/39, where the entire tomogram voxel container was used for scaling mesh coordinates instead of using only a float value for one axis. Fixed by using the x value.